### PR TITLE
importing femebe from github

### DIFF
--- a/pgproto/encoding.go
+++ b/pgproto/encoding.go
@@ -2,8 +2,8 @@ package pgproto
 
 import (
 	"bytes"
-	"femebe"
 	"fmt"
+	"github.com/deafbybeheading/femebe"
 )
 
 func encodeValText(buf *bytes.Buffer,

--- a/pgproto/first.go
+++ b/pgproto/first.go
@@ -15,8 +15,8 @@ package pgproto
 import (
 	"bytes"
 	"errors"
-	"femebe"
 	"fmt"
+	"github.com/deafbybeheading/femebe"
 )
 
 type ErrStartupVersion struct {

--- a/pgproto/first_test.go
+++ b/pgproto/first_test.go
@@ -2,7 +2,7 @@ package pgproto
 
 import (
 	"bytes"
-	"femebe"
+	"github.com/deafbybeheading/femebe"
 	"testing"
 )
 

--- a/pgproto/proto.go
+++ b/pgproto/proto.go
@@ -2,8 +2,8 @@ package pgproto
 
 import (
 	"bytes"
-	. "femebe"
 	"fmt"
+	. "github.com/deafbybeheading/femebe"
 	"reflect"
 )
 

--- a/pgproto/proto_test.go
+++ b/pgproto/proto_test.go
@@ -2,7 +2,7 @@ package pgproto
 
 import (
 	"bytes"
-	"femebe"
+	"github.com/deafbybeheading/femebe"
 	"testing"
 )
 

--- a/pgproto/util_test.go
+++ b/pgproto/util_test.go
@@ -2,7 +2,7 @@ package pgproto
 
 import (
 	"bytes"
-	"femebe"
+	"github.com/deafbybeheading/femebe"
 	"io"
 	"testing"
 )

--- a/tools/simpleproxy.go
+++ b/tools/simpleproxy.go
@@ -3,7 +3,7 @@ package main
 import (
 	"bufio"
 	"crypto/tls"
-	"femebe"
+	"github.com/deafbybeheading/femebe"
 	"fmt"
 	"io"
 	"net"


### PR DESCRIPTION
Same idea than deafbybeheading/dog#2, that makes it easier to get and use `femebe` or `femebe/pgproto` via go tools.
