### PR TITLE
Remove gratuitous and dangerous global variable

### DIFF
--- a/message.go
+++ b/message.go
@@ -63,9 +63,8 @@ func (m *Message) Force() ([]byte, error) {
 	return m.buffered.Bytes(), err
 }
 
-var bufBack [4]byte
-
 func (m *Message) WriteTo(w io.Writer) (_ int64, err error) {
+	var bufBack [4]byte
 	var totalN int64
 
 	if mt := m.MsgType(); mt != MSG_TYPE_FIRST {


### PR DESCRIPTION
It may have prevented GC churn, but the bugs it can cause under
concurrency are going to be weird and terrible.  This is more like a
style used in all the other functions anyway, with a slice pointing to
a stack value.

Signed-off-by: Daniel Farina daniel@fdr.io
