### PR TITLE
Fix confusion in Message.Force

### DIFF
--- a/core/framing.go
+++ b/core/framing.go
@@ -46,17 +46,15 @@ func (m *Message) Force() ([]byte, error) {
 
 	payloadSz := m.Size() - 4
 	curBuf := m.buffered.Bytes()
-	var buf []byte
+	var payload []byte
 
-	if uint32(cap(curBuf)) < payloadSz {
-		buf = make([]byte, len(curBuf), payloadSz)
-		copy(buf, curBuf)
+	// Try to reuse the buffer if possible
+	if uint32(cap(curBuf)) >= payloadSz {
+		payload = curBuf[:payloadSz]
 	} else {
-		buf = curBuf
+		payload = make([]byte, payloadSz)
 	}
-
-	payload := buf[:payloadSz]
-	_, err := io.ReadFull(m.future, payload)
+	_, err := io.ReadFull(m.union, payload)
 
 	m.buffered.InitReader(payload)
 	m.future = nil


### PR DESCRIPTION
This is how I think Message.Force() should look like.  Fixes a bug (as noted in #22), removes an ineffective copy() and eliminates general confusion.