### PR TITLE
Add *Message.Discard

### DIFF
--- a/core/framing.go
+++ b/core/framing.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"github.com/uhoh-itsmaciek/femebe/buf"
 	"io"
+	"io/ioutil"
 )
 
 var ErrTooLarge = errors.New("Message buffering size limit exceeded")
@@ -37,6 +38,15 @@ func (m *Message) Size() uint32 {
 
 func (m *Message) IsBuffered() bool {
 	return m.future == nil
+}
+
+func (m *Message) Discard() error {
+	if m.IsBuffered() {
+		return nil
+	}
+	_, err := io.Copy(ioutil.Discard, m.future)
+	m.future = nil
+	return err
 }
 
 func (m *Message) Force() ([]byte, error) {


### PR DESCRIPTION
Even if the reader is not interested in the contents of a message, it
must read from the future until EOF to avoid losing track of message
boundaries.  Provide a method for doing that easily and efficiently.

I hope I didn't miss anything, but currently Force() seems to be the easiest way to do this, and its interface is suboptimal and it does extra work for no benefit.  Any thoughts on adding this method for convenience?